### PR TITLE
Use stable "slim/psr7" dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "symfony/config": "^3.4 || ^4",
     "symfony/http-kernel": "^3.4 || ^4",
     "symfony/dependency-injection": "^3.4 || ^4",
-    "slim/psr7": "^0.3"
+    "slim/psr7": "^1.0"
   },
   "require-dev": {
     "phpunit/phpunit": "@stable"


### PR DESCRIPTION
As I can see, interfaces between `0.3.0` and `1.0.0` are compatible

https://github.com/slimphp/Slim-Psr7/compare/0.3.0...master